### PR TITLE
Add demonstration main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,1 +1,34 @@
-package messagepack_project
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+
+	"github.com/HackHow/messagepack-project/pkg/msgpack"
+)
+
+func main() {
+	// 範例 JSON 字串
+	inputJSON := `{
+		"name": "Howard",
+		"age": 26,
+		"isDeveloper": true,
+		"skills": ["Go", "JavaScript"],
+		"profile": { "github": "howardshen", "level": 5 }
+	}`
+
+	// JSON → MessagePack
+	msgPackData, err := msgpack.EncodeJSONToMsgPack([]byte(inputJSON))
+	if err != nil {
+		log.Fatal("Encode Error:", err)
+	}
+	fmt.Println("✅ MessagePack (hex):", hex.EncodeToString(msgPackData))
+
+	// MessagePack → JSON
+	outputJSON, err := msgpack.DecodeMsgPackToJSON(msgPackData)
+	if err != nil {
+		log.Fatal("Decode Error:", err)
+	}
+	fmt.Println("✅ Decoded JSON:", string(outputJSON))
+}


### PR DESCRIPTION
This PR adds a demonstration file `main.go` that showcases how to use the custom MessagePack encoder and decoder.

### Features:
- Encodes a sample JSON string into MessagePack format
- Decodes it back to JSON
- Outputs results to terminal with hex-encoded MessagePack view

This makes it easy to validate the correctness of the library manually.
