### PR TITLE
Add HEX output formatting and fix test package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/hex"
 	"fmt"
 	"log"
 
@@ -23,7 +22,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Encode Error:", err)
 	}
-	fmt.Println("✅ MessagePack (hex):", hex.EncodeToString(msgPackData))
+	fmt.Println("✅ MessagePack (hex):", FormatHex(msgPackData))
 
 	// MessagePack → JSON
 	outputJSON, err := msgpack.DecodeMsgPackToJSON(msgPackData)
@@ -31,4 +30,16 @@ func main() {
 		log.Fatal("Decode Error:", err)
 	}
 	fmt.Println("✅ Decoded JSON:", string(outputJSON))
+}
+
+// FormatHex returns a formatted HEX string with each byte separated by a space.
+func FormatHex(data []byte) string {
+	var output string
+	for i, b := range data {
+		if i > 0 {
+			output += " "
+		}
+		output += fmt.Sprintf("%02X", b)
+	}
+	return output
 }

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -1,1 +1,1 @@
-package messagepack_project
+package main


### PR DESCRIPTION
This PR includes two changes to improve the usability and correctness of the demo and test code:

### Changes
1. **Add `FormatHex([]byte)` function to `main.go`**  
   Formats MessagePack binary output into readable hex format (e.g. `A1 62 63`) for better comparison with online tools and reference libraries.

2. **Fix `package` declaration in `msgpack_test.go`**  
   Previously declared as `package messagepack_project`, which does not match the actual module name and causes test failures.  
   It is now corrected to `package main` to align with the module and allow proper test execution.

---

### Specification Compliance Note
This implementation complies with the MessagePack specification by using valid encoding types:
- fixint, fixstr, fixarray
- str8, array16, map16

While it does not currently implement str16, str32, array32, or map32, it still produces valid and decodable output.  
This ensures correctness for typical JSON inputs and compatibility with standard MessagePack decoders.

