### PR TITLE
Support full MessagePack spec and add CLI-based JSON/HEX converter

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,45 +1,83 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/HackHow/messagepack-project/pkg/msgpack"
 )
 
 func main() {
-	// 範例 JSON 字串
-	inputJSON := `{
-		"name": "Howard",
-		"age": 26,
-		"isDeveloper": true,
-		"skills": ["Go", "JavaScript"],
-		"profile": { "github": "howardshen", "level": 5 }
-	}`
+	mode := flag.String("mode", "encode", "Mode: encode or decode")
+	input := flag.String("input", "", "JSON string for encode, or HEX string for decode")
+	flag.Parse()
 
-	// JSON → MessagePack
-	msgPackData, err := msgpack.EncodeJSONToMsgPack([]byte(inputJSON))
-	if err != nil {
-		log.Fatal("Encode Error:", err)
+	if *input == "" {
+		log.Fatal("❌ Please provide input via --input flag.")
 	}
-	fmt.Println("✅ MessagePack (hex):", FormatHex(msgPackData))
 
-	// MessagePack → JSON
-	outputJSON, err := msgpack.DecodeMsgPackToJSON(msgPackData)
-	if err != nil {
-		log.Fatal("Decode Error:", err)
+	switch *mode {
+	case "encode":
+		msgPackData, err := msgpack.EncodeJSONToMsgPack([]byte(*input))
+
+		if err != nil {
+			log.Fatalf("Encode Error: %v", err)
+		}
+
+		fmt.Println("✅ MessagePack (hex):", formatHex(msgPackData))
+
+	case "decode":
+		hexClean := strings.ReplaceAll(*input, " ", "")
+		data, err := decodeHexString(hexClean)
+
+		if err != nil {
+			log.Fatalf("Invalid HEX input: %v", err)
+		}
+
+		jsonData, err := msgpack.DecodeMsgPackToJSON(data)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "empty buffer") {
+				log.Fatal("Decode Error: input appears to be truncated or malformed HEX data.")
+			}
+			log.Fatalf("Decode Error: %v", err)
+		}
+
+		fmt.Println("✅ Decoded JSON:")
+		fmt.Println(string(jsonData))
+
+	default:
+		log.Fatalf("❌ Unsupported mode: %s. Use 'encode' or 'decode'", *mode)
 	}
-	fmt.Println("✅ Decoded JSON:", string(outputJSON))
 }
 
-// FormatHex returns a formatted HEX string with each byte separated by a space.
-func FormatHex(data []byte) string {
-	var output string
+func formatHex(data []byte) string {
+	var output strings.Builder
+
 	for i, b := range data {
 		if i > 0 {
-			output += " "
+			output.WriteString(" ")
 		}
-		output += fmt.Sprintf("%02X", b)
+		output.WriteString(fmt.Sprintf("%02X", b))
 	}
-	return output
+
+	return output.String()
+}
+
+func decodeHexString(s string) ([]byte, error) {
+	if len(s)%2 != 0 {
+		return nil, fmt.Errorf("hex string must be even length")
+	}
+
+	res := make([]byte, len(s)/2)
+	for i := 0; i < len(res); i++ {
+		_, err := fmt.Sscanf(s[2*i:2*i+2], "%02X", &res[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
 }

--- a/pkg/msgpack/encode.go
+++ b/pkg/msgpack/encode.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"reflect"
 )
 
+// EncodeJSONToMsgPack converts JSON bytes to MessagePack format.
 func EncodeJSONToMsgPack(jsonData []byte) ([]byte, error) {
 	var v interface{}
 	if err := json.Unmarshal(jsonData, &v); err != nil {
@@ -35,27 +37,61 @@ func encodeValue(buf *bytes.Buffer, v interface{}) error {
 		for i := 7; i >= 0; i-- {
 			buf.WriteByte(byte(bits >> (i * 8)))
 		}
+	case float32:
+		buf.WriteByte(0xca)
+		bits := math.Float32bits(val)
+		for i := 3; i >= 0; i-- {
+			buf.WriteByte(byte(bits >> (i * 8)))
+		}
 	case string:
 		strLen := len(val)
 		if strLen <= 31 {
 			buf.WriteByte(0xa0 | byte(strLen))
-		} else {
+		} else if strLen <= 255 {
 			buf.WriteByte(0xd9)
 			buf.WriteByte(byte(strLen))
+		} else {
+			buf.WriteByte(0xda)
+			buf.Write([]byte{byte(strLen >> 8), byte(strLen)})
 		}
 		buf.WriteString(val)
-	case float32:
-		buf.WriteByte(0xca)
-		// not used in json.Unmarshal, just in case
-	case int, int8, int16, int32, int64:
-		return encodeInt(buf, int64(val.(int))) // 強轉處理
-	case uint, uint8, uint16, uint32, uint64:
-		return encodeInt(buf, int64(val.(uint))) // 強轉處理
+	// 分別處理 signed 整數
+	case int:
+		return encodeSignedInt(buf, int64(val))
+	case int8:
+		return encodeSignedInt(buf, int64(val))
+	case int16:
+		return encodeSignedInt(buf, int64(val))
+	case int32:
+		return encodeSignedInt(buf, int64(val))
+	case int64:
+		return encodeSignedInt(buf, val)
+	// 分別處理 unsigned 整數
+	case uint:
+		return encodeUnsignedInt(buf, uint64(val))
+	case uint8:
+		return encodeUnsignedInt(buf, uint64(val))
+	case uint16:
+		return encodeUnsignedInt(buf, uint64(val))
+	case uint32:
+		return encodeUnsignedInt(buf, uint64(val))
+	case uint64:
+		return encodeUnsignedInt(buf, val)
 	case []interface{}:
-		if len(val) <= 15 {
-			buf.WriteByte(0x90 | byte(len(val)))
+		length := len(val)
+		if length <= 15 {
+			buf.WriteByte(0x90 | byte(length))
+		} else if length <= 65535 {
+			buf.WriteByte(0xdc)
+			buf.Write([]byte{byte(length >> 8), byte(length)})
 		} else {
-			buf.Write([]byte{0xdc, byte(len(val) >> 8), byte(len(val))})
+			buf.WriteByte(0xdd)
+			buf.Write([]byte{
+				byte(length >> 24),
+				byte(length >> 16),
+				byte(length >> 8),
+				byte(length),
+			})
 		}
 		for _, elem := range val {
 			if err := encodeValue(buf, elem); err != nil {
@@ -63,10 +99,20 @@ func encodeValue(buf *bytes.Buffer, v interface{}) error {
 			}
 		}
 	case map[string]interface{}:
-		if len(val) <= 15 {
-			buf.WriteByte(0x80 | byte(len(val)))
+		length := len(val)
+		if length <= 15 {
+			buf.WriteByte(0x80 | byte(length))
+		} else if length <= 65535 {
+			buf.WriteByte(0xde)
+			buf.Write([]byte{byte(length >> 8), byte(length)})
 		} else {
-			buf.Write([]byte{0xde, byte(len(val) >> 8), byte(len(val))})
+			buf.WriteByte(0xdf)
+			buf.Write([]byte{
+				byte(length >> 24),
+				byte(length >> 16),
+				byte(length >> 8),
+				byte(length),
+			})
 		}
 		for k, v := range val {
 			if err := encodeValue(buf, k); err != nil {
@@ -77,25 +123,104 @@ func encodeValue(buf *bytes.Buffer, v interface{}) error {
 			}
 		}
 	default:
-		return fmt.Errorf("unsupported type: %T", val)
+		// 若型別不符合以上情形，嘗試使用 reflection
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return encodeSignedInt(buf, rv.Int())
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return encodeUnsignedInt(buf, rv.Uint())
+		default:
+			return fmt.Errorf("unsupported type: %T", v)
+		}
 	}
 	return nil
 }
 
-func encodeInt(buf *bytes.Buffer, n int64) error {
-	if n >= 0 && n <= 127 {
+// encodeSignedInt encodes a signed integer according to MessagePack spec.
+func encodeSignedInt(buf *bytes.Buffer, n int64) error {
+	if n >= 0 {
+		if n <= 127 {
+			buf.WriteByte(byte(n))
+			return nil
+		}
+		// 對於正數，若超出 positive fixint 範圍，可考慮仍使用 signed int 編碼
+		if n <= 255 {
+			buf.WriteByte(0xd0) // int8
+			buf.WriteByte(byte(n))
+		} else if n <= 32767 {
+			buf.WriteByte(0xd1) // int16
+			buf.Write([]byte{byte(n >> 8), byte(n)})
+		} else if n <= 2147483647 {
+			buf.WriteByte(0xd2) // int32
+			buf.Write([]byte{
+				byte(n >> 24),
+				byte(n >> 16),
+				byte(n >> 8),
+				byte(n),
+			})
+		} else {
+			buf.WriteByte(0xd3) // int64
+			buf.Write([]byte{
+				byte(n >> 56),
+				byte(n >> 48),
+				byte(n >> 40),
+				byte(n >> 32),
+				byte(n >> 24),
+				byte(n >> 16),
+				byte(n >> 8),
+				byte(n),
+			})
+		}
+	} else {
+		// 負數部分
+		if n >= -32 {
+			buf.WriteByte(0xe0 | byte(n+32))
+		} else if n >= -128 {
+			buf.WriteByte(0xd0)
+			buf.WriteByte(byte(n))
+		} else if n >= -32768 {
+			buf.WriteByte(0xd1)
+			buf.Write([]byte{byte(n >> 8), byte(n)})
+		} else if n >= -2147483648 {
+			buf.WriteByte(0xd2)
+			buf.Write([]byte{
+				byte(n >> 24),
+				byte(n >> 16),
+				byte(n >> 8),
+				byte(n),
+			})
+		} else {
+			buf.WriteByte(0xd3)
+			buf.Write([]byte{
+				byte(n >> 56),
+				byte(n >> 48),
+				byte(n >> 40),
+				byte(n >> 32),
+				byte(n >> 24),
+				byte(n >> 16),
+				byte(n >> 8),
+				byte(n),
+			})
+		}
+	}
+	return nil
+}
+
+// encodeUnsignedInt encodes an unsigned integer using MessagePack unsigned codes.
+func encodeUnsignedInt(buf *bytes.Buffer, n uint64) error {
+	if n <= 127 {
 		buf.WriteByte(byte(n))
-	} else if n >= -32 && n < 0 {
-		buf.WriteByte(0xe0 | byte(n+32))
-	} else if n >= -128 && n <= 127 {
-		buf.WriteByte(0xd0)
+		return nil
+	}
+	if n <= 0xff {
+		buf.WriteByte(0xcc) // uint8
 		buf.WriteByte(byte(n))
-	} else if n >= -32768 && n <= 32767 {
-		buf.WriteByte(0xd1)
-		buf.WriteByte(byte(n >> 8))
-		buf.WriteByte(byte(n))
-	} else if n >= -2147483648 && n <= 2147483647 {
-		buf.WriteByte(0xd2)
+	} else if n <= 0xffff {
+		buf.WriteByte(0xcd) // uint16
+		buf.Write([]byte{byte(n >> 8), byte(n)})
+	} else if n <= 0xffffffff {
+		buf.WriteByte(0xce) // uint32
 		buf.Write([]byte{
 			byte(n >> 24),
 			byte(n >> 16),
@@ -103,7 +228,7 @@ func encodeInt(buf *bytes.Buffer, n int64) error {
 			byte(n),
 		})
 	} else {
-		buf.WriteByte(0xd3)
+		buf.WriteByte(0xcf) // uint64
 		buf.Write([]byte{
 			byte(n >> 56),
 			byte(n >> 48),


### PR DESCRIPTION
# MessagePack Implementation PR

This PR introduces two major updates:

## 1. Encoder & Decoder Coverage

- The MessagePack encoder and decoder now support the full specification:
  - Strings: fixstr, str8, str16
  - Arrays: fixarray, array16, array32
  - Maps: fixmap, map16, map32
  - Integers: full range of signed and unsigned types (int8\~64, uint8~64)
- Ensures symmetry between encoding and decoding logic.

## 2. main.go CLI Conversion

- Refactors main.go into a command-line interface tool.
- Accepts --mode encode|decode and --input parameters.
- Users can manually input JSON or HEX for conversion without modifying the source file.

---

## ✅ Usage

Encode JSON:

```bash
go run . --mode encode --input '{"device_id":"cam001","fps":30}'
```

Decode HEX:

```bash
go run . --mode decode --input "82 A9 64 65 76 69 63 65 5F 69 64 A6 63 61 6D 30 30 31 A3 66 70 73 1E"
```

## 🔧 Testing & Verification

For verification of MessagePack HEX values, you can use the online tool at https://kawanet.github.io/msgpack-lite/

This browser-based utility allows you to:
- Paste JSON and see the corresponding MessagePack HEX
- Paste HEX and see the decoded JSON
- Interactively verify the correctness of conversions used in this PR